### PR TITLE
Trim newlines when reading PASSWORD_FILE

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -10,7 +10,7 @@ module.exports.PASSWORD = process.env.PASSWORD;
 // if not, then print the error and proceed
 if ('PASSWORD_FILE' in process.env && fs.existsSync(process.env.PASSWORD_FILE)) {
   try {
-    module.exports.PASSWORD = fs.readFileSync(process.env.PASSWORD_FILE, 'utf8');
+    module.exports.PASSWORD = fs.readFileSync(process.env.PASSWORD_FILE, 'utf8').replace(/[\n\r]/g, '');
   } catch (err) {
     console.error('Could not load the PASSWORD_FILE, using the contents of the PASSWORD variable instead');
   }


### PR DESCRIPTION
I just tried deploying docker secrets with the password file but `fs.readFileSync()` kept inserting a newline character at the end and so password would keep failing.

Created password file with:
```
echo "test_passwd" > ./password
```
Not sure why, I am not a JS dev. I could only get it to work by trimming the newline characters.

Also I agree about the staleness of wg-easy. It also doesn't feel like a community project, more like a dictator project after looking at other PRs and Issues.
Forking isn't a bad idea.